### PR TITLE
Fix parsing issue when colon is directly after variable

### DIFF
--- a/addons/inspector_extender/inspector_plugin.gd
+++ b/addons/inspector_extender/inspector_plugin.gd
@@ -143,7 +143,10 @@ func get_suffix(to_find : String, line : String):
 				):
 					string_chars_matched += 1
 					if string_chars_matched == to_find.length():
-						return line.substr(i + 1, line.find(" ", i + to_find.length()) - i - 1)
+						var result = line.substr(i + 1, line.find(" ", i + to_find.length()) - i - 1)
+						if result.ends_with(":"):
+							result = result.trim_suffix(":")
+						return result
 
 				else:
 					string_chars_matched = 0


### PR DESCRIPTION
I fixed an issue I had due to the syntax that I use for variable typing. The original parsing expects `@export var name : type` but I typically use `@export var name: type`. This edit supports both variants.