### PR TITLE
Rework how show_if controls other attributes and variables

### DIFF
--- a/addons/inspector_extender/attributes/show_if.gd
+++ b/addons/inspector_extender/attributes/show_if.gd
@@ -1,29 +1,49 @@
-extends Control
+# using MarginContainer to automatically fit to child elements
+extends MarginContainer
 
 var object : Object
 var attached_prop : Control
 var expression : Expression
-
+var property : String
+var child_nodes = []
+var is_initialized = false
 
 func _initialize(object, property, attribute_name, params, inspector_plugin):
 	self.object = object
+	self.property = property
 	expression = Expression.new()
 	expression.parse(params[0])
-
+	_ready()
 
 func _ready():
-	var cur_index := get_index() - 1
-	while !get_parent().get_child(cur_index) is EditorProperty:
-		cur_index -= 1
+	# ensure everything is ready before searching the tree
+	if is_initialized or property.is_empty() or !is_inside_tree():
+		return
+	
+	is_initialized = true
+	for child in get_parent().get_children():
+		if child is EditorProperty and attached_prop == null \
+		and (child as EditorProperty).get_edited_property() == property:
+			attached_prop = child
+			break
+	
+	for child in child_nodes:
+		child.reparent(self)
 
-	attached_prop = get_parent().get_child(cur_index)
-	hide()
+	if attached_prop == null && child_nodes.size() == 0:
+		push_warning("show_if attribute could not find %s property" % property)
+	elif attached_prop != null:
+		child_nodes.append(attached_prop)
+		attached_prop.reparent(self)
 
 
 func _update_view():
+	if child_nodes.size() == 0: return
 	var shown = expression.execute([], object)
 	await get_tree().process_frame
-	attached_prop.visible = shown
+	self.visible = shown
 
 
 func _hides_property(): return false
+
+func _is_show_if_attribute(): return true

--- a/addons/inspector_extender/plugin.cfg
+++ b/addons/inspector_extender/plugin.cfg
@@ -3,5 +3,5 @@
 name="Inspector Extender"
 description="Use comments to extend the Inspector."
 author="Don Tnowe"
-version="0.1"
+version="0.2"
 script="plugin.gd"

--- a/example/scripts/new_gd_script.gd
+++ b/example/scripts/new_gd_script.gd
@@ -24,6 +24,8 @@ extends Node2D
 # @@buttons(#009900, "Move(9, 20)", set_position(position + Vector2(9, 20)), "Reset", #990000, _reset())
 @export var var3 : Array[Resource]
 
+# @@show_if(var_enum == 2)
+@export var var7 := 0
 
 func _negative_message():
 	return "" if var1 >= 0 else "Negative values cause unpredictable behaviour."


### PR DESCRIPTION
I've reduced down the previous PR to only be applicable to `show_if`. The final property is handled in `_parse_end` and due to that behavior, `_ready` is called before `_initialize` which is why there is a guard block to make sure the tree is ready to parse.

Resolves #5 