### PR TITLE
Fix bugs

### DIFF
--- a/addons/inspector_extender/inspector_plugin.gd
+++ b/addons/inspector_extender/inspector_plugin.gd
@@ -101,7 +101,10 @@ func create_editable_copy(object):
 
 		if x["usage"] & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP) != 0:
 			continue
-
+		
+		if x["name"] == "resource_path":
+			continue
+		
 		new_object.set(x["name"], object[x["name"]])
 
 	return new_object

--- a/addons/inspector_extender/inspector_plugin.gd
+++ b/addons/inspector_extender/inspector_plugin.gd
@@ -151,7 +151,7 @@ func get_suffix(to_find : String, line : String):
 				):
 					string_chars_matched += 1
 					if string_chars_matched == to_find.length():
-						var result = line.substr(i + 1, line.find(" ", i + to_find.length()) - i - 1)
+						var result = line.substr(i + 1, line.find(" ", i + 1) - i - 1)
 						if result.ends_with(":"):
 							result = result.trim_suffix(":")
 						return result


### PR DESCRIPTION
# Fix get_suffix when the variable name is just 1 letter long

When the variable name was just 1 letter long, `get_suffix` would return an empty string, so the attributes wouldn't work for that variable.
Now 1 letter long variable names work correctly.

# Fix error when editing an object that doesn't have a script attached

If you edited an object without a script attached, it would give the error:

"Invalid get index 'property_name' ".

This happened because it was trying to access that property in an object that was previously handled by the plugin.

This was fixed by resetting the state of the variables on the `_can_handle` method and making a null check in `_on_edited_object_changed`, so it doesn't try to update a variable on an object that the plugin is not currently handling.

# Fix error “Another resource is loaded from path” when opening a .tres file

When you opened a .tres file, it would give the error:

"Another resource is loaded from path 'res://path/my_file.tres' (possible cyclic resource inclusion)."

This happened because during `create_editable_copy`, the `resource_path` property would be assigned to the new object. This failed, as [stated in the documentation](https://docs.godotengine.org/en/stable/classes/class_resource.html#class-resource-property-resource-path):

> Setting this property manually may fail if a resource with the same path has already been previously loaded.

It was fixed by skipping the `resource_path` property when assigning the property values.